### PR TITLE
Migrate value defaults for instructor choices to JS

### DIFF
--- a/mod/lti/mod_form.js
+++ b/mod/lti/mod_form.js
@@ -43,7 +43,6 @@
             this.toolTypeCache = {};
 
             this.addOptGroups();
-
             var updateToolMatches = function(){
                 self.updateAutomaticToolMatch(Y.one('#id_toolurl'));
                 self.updateAutomaticToolMatch(Y.one('#id_securetoolurl'));
@@ -58,17 +57,7 @@
 
                 self.toggleEditButtons();
 
-                if (self.getSelectedToolTypeOption().getAttribute('toolproxy')){
-                    var allowname = Y.one('#id_instructorchoicesendname');
-                    allowname.set('checked', !self.getSelectedToolTypeOption().getAttribute('noname'));
-
-                    var allowemail = Y.one('#id_instructorchoicesendemailaddr');
-                    allowemail.set('checked', !self.getSelectedToolTypeOption().getAttribute('noemail'));
-
-                    var allowgrades = Y.one('#id_instructorchoiceacceptgrades');
-                    allowgrades.set('checked', !self.getSelectedToolTypeOption().getAttribute('nogrades'));
-                    self.toggleGradeSection();
-                }
+                self.updateInstructorChoices(self.getSelectedToolTypeOption());
             });
 
             var contentItemButton = Y.one('[name="selectcontent"]');
@@ -120,6 +109,36 @@
             allowgrades.on('change', this.toggleGradeSection, this);
 
             updateToolMatches();
+            this.updateInstructorChoices(this.getSelectedToolTypeOption());
+        },
+
+        updateInstructorChoices: function(typeid) {
+        	var self = this;
+        	var sendname = Y.one('[name="instructorchoicesendname"]')
+        	var sendemailaddr = Y.one('[name="instructorchoicesendemailaddr"]')
+        	var acceptgrades = Y.one('[name="instructorchoiceacceptgrades"]')
+        	sendname.set('value', '1');
+        	sendemailaddr.set('value', '1');
+        	acceptgrades.set('value', '1');
+        	if(typeid) {
+        		if(typeid.getAttribute('toolproxy')) {
+                    var allowname = Y.one('#id_instructorchoicesendname');
+                    var noname = typeid.getAttribute('noname');
+                    allowname.set('checked', !noname);
+                	sendname.set('value', noname ? '0' : '1');
+
+                    var allowemail = Y.one('#id_instructorchoicesendemailaddr');
+                    var noemail = typeid.getAttribute('noemail');
+                    allowemail.set('checked', !noemail);
+                    sendemailaddr.set('value', noemail ? '0' : '1');
+
+                    var allowgrades = Y.one('#id_instructorchoiceacceptgrades');
+                    var nogrades = typeid.getAttribute('nogrades');
+                    allowgrades.set('checked', !nogrades);
+                    acceptgrades.set('value', nogrades ? '0' : '1');
+                    self.toggleGradeSection();
+        		}
+        	}
         },
 
         toggleGradeSection: function(e) {

--- a/mod/lti/mod_form.php
+++ b/mod/lti/mod_form.php
@@ -216,17 +216,14 @@ class mod_lti_mod_form extends moodleform_mod {
         $mform->addElement('header', 'privacy', get_string('privacy', 'lti'));
 
         $mform->addElement('advcheckbox', 'instructorchoicesendname', '&nbsp;', ' ' . get_string('share_name', 'lti'));
-        $mform->setDefault('instructorchoicesendname', '1');
         $mform->addHelpButton('instructorchoicesendname', 'share_name', 'lti');
         $mform->disabledIf('instructorchoicesendname', 'typeid', 'in', $toolproxy);
 
         $mform->addElement('advcheckbox', 'instructorchoicesendemailaddr', '&nbsp;', ' ' . get_string('share_email', 'lti'));
-        $mform->setDefault('instructorchoicesendemailaddr', '1');
         $mform->addHelpButton('instructorchoicesendemailaddr', 'share_email', 'lti');
         $mform->disabledIf('instructorchoicesendemailaddr', 'typeid', 'in', $toolproxy);
 
         $mform->addElement('advcheckbox', 'instructorchoiceacceptgrades', '&nbsp;', ' ' . get_string('accept_grades', 'lti'));
-        $mform->setDefault('instructorchoiceacceptgrades', '1');
         $mform->addHelpButton('instructorchoiceacceptgrades', 'accept_grades', 'lti');
         $mform->disabledIf('instructorchoiceacceptgrades', 'typeid', 'in', $toolproxy);
 


### PR DESCRIPTION
Since mod_form.php is created when handling activity creation, the defaults for grading resulted downstream in grade items being created regardless of what the user selected.  To preserve current behavior of the LTI module, moved the logic for defaulting the values into mod_form.js so that user experience wouldn't change but form submissions work appropriately