### PR TITLE
MDL-60007 MOD_LTI: Delete does not work without Content-Type

### DIFF
--- a/mod/lti/services.php
+++ b/mod/lti/services.php
@@ -33,6 +33,7 @@ require_once($CFG->dirroot . '/mod/lti/locallib.php');
 $response = new \mod_lti\local\ltiservice\response();
 
 $isget = $response->get_request_method() == 'GET';
+$isdelete = $response->get_request_method() == 'DELETE';
 
 if ($isget) {
     $response->set_accept(isset($_SERVER['HTTP_ACCEPT']) ? $_SERVER['HTTP_ACCEPT'] : '');
@@ -51,7 +52,7 @@ foreach ($services as $service) {
     foreach ($resources as $resource) {
         if (($isget && !empty($accept) && (strpos($accept, '*/*') === false) &&
              !in_array($accept, $resource->get_formats())) ||
-            (!$isget && !in_array($response->get_content_type(), $resource->get_formats()))) {
+            ((!$isget && !$isdelete) && !in_array($response->get_content_type(), $resource->get_formats()))) {
             continue;
         }
         $template = $resource->get_template();


### PR DESCRIPTION
https://tracker.moodle.org/browse/MDL-60007  
This is a bug that we have found in the mod/lti code.