### PR TITLE
Added paging & filtering to the GradeBook Services v2 LineItems, Results and Scores

### DIFF
--- a/mod/lti/service/gradebookservices/classes/local/resource/lineitem.php
+++ b/mod/lti/service/gradebookservices/classes/local/resource/lineitem.php
@@ -83,7 +83,7 @@ class lineitem extends \mod_lti\local\ltiservice\resource_base {
                 throw new \Exception(null, 400);
             }
             if (($item = $this->get_service()->get_lineitem($contextid, $itemid, !$isdelete)) === false) {
-                throw new \Exception(null, 400);
+                throw new \Exception(null, 404);
             }
             require_once($CFG->libdir.'/gradelib.php');
             switch ($response->get_request_method()) {


### PR DESCRIPTION
Added paging to the GradeBook Services v2 LineItems, Results and Scores
and also added filtering of Line Items by resource_id and/or
resource_link_id.

Paging parameters are limit and from (page offset) to align more with the
LTI Memberships service implementation, since the Gradebook Services V2
specification leaves that as an implementation detail.